### PR TITLE
All movt cs

### DIFF
--- a/GetBlacksInMOV.py
+++ b/GetBlacksInMOV.py
@@ -83,6 +83,7 @@ def timecode(h, m, s, f):
 
 print "Choose the source directory for the MOV files"
 directory = tkFileDialog.askdirectory()
+AllMOVTCs = 'n'
 
 for root, dirs, files in os.walk(directory):
     for file in files:
@@ -96,15 +97,22 @@ for root, dirs, files in os.walk(directory):
             with open(logfile, 'r') as log_file:
                 (hh, mm, ss, ff, rate) = StartTC(log_file)
                 if hh==() and mm==() and ss==() and ff==():
-                    print "No Timecode in metadata.\n"
-                    userTC = raw_input("Enter the start timecode of the movie file excluding colons (hhmmssff)\n")
-                    print "You entered "+userTC+"\n"
-                    MOVTC = userTC[0:2]+":"+userTC[2:4]+":"+userTC[4:6]+":"+userTC[6:]
-                    print 'User Entered Start TimeCode is '+MOVTC
-                    hh=int(userTC[0:2])
-                    mm=int(userTC[2:4])
-                    ss=int(userTC[4:6])
-                    ff=int(userTC[6:])
+                    if AllMOVTCs == 'n':
+                        print "No Timecode in metadata.\n"
+                        userTC = raw_input("Enter the start timecode of the movie file excluding colons (hhmmssff)\n")
+                        print "You entered "+userTC+"\n"
+                        AllMOVTCs = raw_input("Will this be the start TC for all MOV files? [y/n]")
+                        MOVTC = userTC[0:2]+":"+userTC[2:4]+":"+userTC[4:6]+":"+userTC[6:]
+                        print 'User Entered Start TimeCode is '+MOVTC
+                        hh=int(userTC[0:2])
+                        mm=int(userTC[2:4])
+                        ss=int(userTC[4:6])
+                        ff=int(userTC[6:])
+                    else:
+                        hh=int(userTC[0:2])
+                        mm=int(userTC[2:4])
+                        ss=int(userTC[4:6])
+                        ff=int(userTC[6:])
                 else:
                     MOVTC = str(hh)+':'+str(mm)+':'+str(ss)+':'+str(ff)
                     print 'Start TimeCode is '+ MOVTC

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ THE LOG FILE IS THEN READ AND THE BLACK_START TIMES ARE CONVERTED TO TIME CODE A
 
 ASSUMPTIONS:
 This script assumes all MOV files are 23.98fps. I haven't put in provisions for other frame rates.
+This branch makes it so you only have to enter a user inputed time code once if all the MOVs in your folder have the same start time code.
 
 Requires TKinter module.
 


### PR DESCRIPTION
After the first movie file is analyzed, if there's no time code in the metadata, the script asks the user to input the start time code. The previous code would do this for every movie in the folder if they all didn't have a time code track. Defeats the purpose of set and forget. Now it asks for the TC after the first movie is done and if it will be the same for the rest. One still has to wait for the first MOV to be completed (approx. 4 min. per 1 hour MOV).
